### PR TITLE
feat: Add integer types to metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8645,7 +8645,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-lang"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "exitcode",
@@ -8660,7 +8660,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-node"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "async-trait",
  "bs58 0.5.0",
@@ -8713,7 +8713,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-node-runtime"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -8774,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-runtime-types"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "frame-support",
  "pallet-process-validation",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'sqnc-node'
-version = '11.0.0'
+version = '11.1.0'
 
 [[bin]]
 name = 'sqnc-node'

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqnc-node-runtime"
-version = "11.0.0"
+version = "11.1.0"
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("sqnc"),
     impl_name: create_runtime_str!("sqnc"),
     authoring_version: 1,
-    spec_version: 1100,
+    spec_version: 1110,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/types/Cargo.toml
+++ b/runtime/types/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'sqnc-runtime-types'
-version = "1.0.2"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/types/src/lib.rs
+++ b/runtime/types/src/lib.rs
@@ -58,6 +58,7 @@ pub enum MetadataValue<TokenId> {
     File(Hash),
     Literal(BoundedVec<u8, ConstU32<32>>),
     TokenId(TokenId),
+    Integer(i128),
     None,
 }
 

--- a/tools/lang/Cargo.toml
+++ b/tools/lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqnc-lang"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/tools/lang/src/ast/types.rs
+++ b/tools/lang/src/ast/types.rs
@@ -41,7 +41,9 @@ pub enum TokenFieldType<'a> {
     File,
     Role,
     Literal,
+    Integer,
     LiteralValue(AstNode<'a, &'a str>),
+    IntegerValue(AstNode<'a, i128>),
     Token(AstNode<'a, &'a str>),
 }
 
@@ -52,7 +54,9 @@ impl<'a> Display for TokenFieldType<'a> {
             TokenFieldType::File => write!(f, "File"),
             TokenFieldType::Role => write!(f, "Role"),
             TokenFieldType::Literal => write!(f, "Literal"),
+            TokenFieldType::Integer => write!(f, "Integer"),
             TokenFieldType::LiteralValue(s) => write!(f, "\"{}\"", s.value),
+            TokenFieldType::IntegerValue(s) => write!(f, "{}", s.value),
             TokenFieldType::Token(s) => write!(f, "{}", s.value),
         }
     }
@@ -151,6 +155,7 @@ pub enum TypeCmpType {
     File,
     Role,
     Literal,
+    Integer,
     Token,
 }
 
@@ -171,6 +176,11 @@ pub enum Comparison<'a> {
         left: AstNode<'a, TokenProp<'a>>,
         op: BoolCmp,
         right: AstNode<'a, &'a str>,
+    },
+    PropInt {
+        left: AstNode<'a, TokenProp<'a>>,
+        op: BoolCmp,
+        right: AstNode<'a, i128>,
     },
     PropSender {
         left: AstNode<'a, TokenProp<'a>>,
@@ -212,6 +222,13 @@ impl<'a> Display for Comparison<'a> {
                     BoolCmp::Neq => "!=",
                 };
                 write!(f, "{}.{} {} \"{}\"", left.value.token, left.value.prop, op, right)
+            }
+            Comparison::PropInt { left, op, right } => {
+                let op = match op {
+                    BoolCmp::Eq => "==",
+                    BoolCmp::Neq => "!=",
+                };
+                write!(f, "{}.{} {} {}", left.value.token, left.value.prop, op, right)
             }
             Comparison::PropSender { left, op } => {
                 let op = match op {
@@ -255,6 +272,7 @@ impl<'a> Display for Comparison<'a> {
                     TypeCmpType::File => "File",
                     TypeCmpType::Role => "Role",
                     TypeCmpType::Literal => "Literal",
+                    TypeCmpType::Integer => "Integer",
                     TypeCmpType::Token => "Token",
                 };
                 write!(f, "{}.{}{} {}", left.value.token, left.value.prop, op, right)

--- a/tools/lang/src/compiler/flatten.rs
+++ b/tools/lang/src/compiler/flatten.rs
@@ -65,6 +65,17 @@ fn transform_comparison<'a>(
             op,
             right,
         }),
+        Comparison::PropInt { left, op, right } => Ok(Comparison::PropInt {
+            left: AstNode {
+                value: TokenProp {
+                    token: transform_name(left.value.token, token_name_transforms.clone())?,
+                    prop: left.value.prop,
+                },
+                span: left.span,
+            },
+            op,
+            right,
+        }),
         Comparison::PropSender { left, op } => Ok(Comparison::PropSender {
             left: AstNode {
                 value: TokenProp {

--- a/tools/lang/src/sqnc.pest
+++ b/tools/lang/src/sqnc.pest
@@ -5,6 +5,7 @@ char = {
     | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")
     | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
+number = ${ "-"? ~ ASCII_DIGIT+ }
 
 ident = @{ !(keyword ~ !(ASCII_ALPHANUMERIC | "_")) ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 ident_prop = { ident ~ "." ~ ident }
@@ -18,13 +19,15 @@ keyword = _{ pub | priv | fn | token | where | sender | bool_op | cmp_op }
 
 file = { "File" }
 literal = { "Literal" }
+integer = { "Integer" }
 role = { "Role" }
 none = { "None" }
 sender = { "sender" }
 literal_value = { string }
+integer_value = { number }
 
-partial_type = _{ file | literal | role | none | literal_value | ident }
-cmp_type = _{ file | literal | role | none }
+partial_type = _{ file | literal | integer | role | none | literal_value | integer_value | ident }
+cmp_type = _{ file | literal | integer | role | none }
 
 type = { partial_type ~ ("|" ~ partial_type)* }
 
@@ -34,6 +37,7 @@ properties = { (field ~ ",")* ~ (field)? }
 token_decl = { token ~ ident ~ "{" ~ properties ~ "}" }
 
 prop_lit_cmp = { ident_prop ~ cmp_op ~ literal_value }
+prop_int_cmp = { ident_prop ~ cmp_op ~ integer_value }
 prop_sender_cmp = { ident_prop ~ cmp_op ~ sender }
 ident_ident_cmp = { ident ~ cmp_op ~ ident }
 prop_ident_cmp = { ident_prop ~ cmp_op ~ ident }
@@ -43,7 +47,7 @@ prop_type_cmp = { ident_prop ~ cmp_type_op ~ cmp_type }
 fn_args = { "|" ~ (ident ~ ",")* ~ ident? ~ "|" }
 fn_cmp = { ident ~ fn_args ~ "=>" ~ fn_args }
 
-cmp = _{ fn_cmp | prop_prop_cmp | prop_lit_cmp | prop_sender_cmp | prop_ident_cmp | ident_ident_cmp | prop_type_cmp }
+cmp = _{ fn_cmp | prop_prop_cmp | prop_lit_cmp | prop_int_cmp | prop_sender_cmp | prop_ident_cmp | ident_ident_cmp | prop_type_cmp }
 
 cmp_op = _{ eq | neq }
     eq = { "==" }


### PR DESCRIPTION
Adds integer types to metadata in the runtime.

This also adds support for integers and integer literals to the language.

Integer values still only support equals and not equals comparisons for now. Baby steps

Documentation PR https://github.com/digicatapult/sqnc-documentation/pull/33