### PR TITLE
new versioning strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-doas"
-version = "2.3.1"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "3.7.1"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5329,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-symmetric-key"
-version = "2.3.1"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-free"
-version = "2.3.1"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-utxo-nft"
-version = "6.4.1"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-lang"
-version = "0.5.1"
+version = "12.0.0"
 dependencies = [
  "clap",
  "exitcode",
@@ -9216,7 +9216,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-pallet-traits"
-version = "3.5.1"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-runtime"
-version = "11.3.1"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9162,7 +9162,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-node"
-version = "11.4.1"
+version = "12.0.0"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "sqnc-runtime-types"
-version = "1.1.1"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "pallet-process-validation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
+version = "12.0.0"
 
 [workspace.dependencies]
 ##############################

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -71,7 +71,7 @@ If tests pass, bump at least a minor version in the pallet `Cargo.toml` e.g. `pa
 
 Test that the upgraded dependencies work for the runtime, including the newly upgraded pallets `cargo build --release -p sqnc-runtime`. Fix any compilation errors.
 
-Bump the runtime version in `runtime/Cargo.toml`. Also increment the runtime `spec_version` in `runtime/src/lib.rs` to match. Note `spec_version` does not recognize semver, so treat it as a whole number. e.g. in place of `5.6.8` the `spec_version` would be `568`.
+Bump the version in top-level `Cargo.toml`. Also increment the runtime `spec_version` in `runtime/src/lib.rs` by one.
 
 Run the tests for the runtime:
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'sqnc-node'
-version = '11.4.1'
+version = { workspace = true }
 
 [[bin]]
 name = 'sqnc-node'

--- a/pallets/doas/Cargo.toml
+++ b/pallets/doas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-doas"
-version = "2.3.1"
+version = { workspace = true }
 authors = [
 	"Digital Catapult <https://www.digicatapult.org.uk>",
 	"Parity Technologies <admin@parity.io>",

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'pallet-process-validation'
-version = "3.7.1"
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/symmetric-key/Cargo.toml
+++ b/pallets/symmetric-key/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'pallet-symmetric-key'
-version = "2.3.1"
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/traits/Cargo.toml
+++ b/pallets/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqnc-pallet-traits"
-version = "3.5.1"
+version = { workspace = true }
 edition = "2021"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
 license = 'Apache-2.0'

--- a/pallets/transaction-payment-free/Cargo.toml
+++ b/pallets/transaction-payment-free/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-payment-free"
-version = "2.3.1"
+version = { workspace = true }
 authors = [
 	"Digital Catapult <https://www.digicatapult.org.uk>",
 	"Parity Technologies <admin@parity.io>",

--- a/pallets/utxo-nft/Cargo.toml
+++ b/pallets/utxo-nft/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'pallet-utxo-nft'
-version = "6.4.1"
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqnc-runtime"
-version = "11.3.1"
+version = { workspace = true }
 authors = ["Digital Catapult <https://www.digicatapult.org.uk>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("sqnc"),
     impl_name: create_runtime_str!("sqnc"),
     authoring_version: 1,
-    spec_version: 1131,
+    spec_version: 1132,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/types/Cargo.toml
+++ b/runtime/types/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/sqnc-node/'
 name = 'sqnc-runtime-types'
-version = "1.1.1"
+version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -43,7 +43,7 @@ function assert_tomlq() {
 
 function get_working_copy_version() {
   assert_tomlq
-  CURRENT_VERSION=$(tomlq .package.version ./node/Cargo.toml | sed 's/"//g')
+  CURRENT_VERSION=$(tomlq .workspace.package.version ./Cargo.toml | sed 's/"//g')
 
   printf "This version found to be %s\n" "$CURRENT_VERSION"
 

--- a/tools/lang/Cargo.toml
+++ b/tools/lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqnc-lang"
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-version = "0.5.1"
+version = { workspace = true }
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [x] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-73

## High level description

Introduced new versioning strategy agreed in SQNC-41.

## Detailed description

The agreed new strategy uses a single version set in the `Cargo.toml` at root level. this is then used by all the other `Cargo.toml`s. 
We are from now on also incrementing `spec_version` by one e.g 1131 -> 1132 as part of a version bump. 
Made a line change in `check-version.sh` to obtain current version from the root `Cargo.toml` instead of one in node. 


## Describe alternatives you've considered

As per SQNC-41, we have considered per-crate versioning strategy and a hybrid versioning approach. We have decided to proceed with Unified versioning as the crates are tightly coupled. 

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
