### PR TITLE
chore: add trufflehog secret scanning

### DIFF
--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -149,3 +149,8 @@ jobs:
           SCCACHE_DIR: ${{ runner.temp }}/cache
           SCCACHE_CACHE_SIZE: "2G"
         run: cargo test
+
+  scan-secrets:
+    uses: digicatapult/shared-workflows/.github/workflows/scan-secrets.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type
- [x] Chore

## Linked tickets
https://digicatapult.atlassian.net/browse/ENG-292

## High level description
Enables TruffleHog secret scanning in CI as required by the Secure Software Development Policy V1.1 and Software Engineering Standard Secure Development Policy V1.1.

## Detailed description
Appends a standalone `scan-secrets` job to `.github/workflows/check-and-test.yml` using the shared `scan-secrets.yml` reusable workflow.

## Describe alternatives you've considered
A standalone `scan-secrets` job was considered but `enable_trufflehog_action: true` is preferred where `static-checks-npm` is already present as it avoids adding a redundant job.

## Operational impact
None — CI-only change.

## Additional context
Part of a compliance audit sweep across the digicatapult org (ENG-292).
